### PR TITLE
Fix stackoverflow link about address space randomization

### DIFF
--- a/intro/README.md
+++ b/intro/README.md
@@ -34,7 +34,7 @@ One issue with mem.c is that address space randomization is usually on by
 default. To turn it off:
 
 ### macOS
-From [stackoverflow](stackoverflow.com/questions/23897963/documented-way-to-disable-aslr-on-os-x)
+From [stackoverflow](http://stackoverflow.com/questions/23897963/documented-way-to-disable-aslr-on-os-x)
 
 Just compile/link as follows:
     gcc -o mem mem.c -Wall -Wl,-no_pie
@@ -43,9 +43,9 @@ Just compile/link as follows:
 
 From Giovanni Lagorio:
 
-Under Linux you can disable ASLR, without using a debugger, in (at least)  two ways: 
+Under Linux you can disable ASLR, without using a debugger, in (at least)  two ways:
 * Use the command setarch to run a process with ASLR disabled; I typically run
-  bash, with which I can execute examples, like this: 
+  bash, with which I can execute examples, like this:
   `setarch $(uname --machine) --addr-no-randomize /bin/bash`
 * Writing 0 into `/proc/sys/kernel/randomize_va_space`; you need to be
   root to do this and this change has (a non-permament) effect on the


### PR DESCRIPTION
A minor fix.
As it is, the link to StackOverflow was considered relative and thus added after http://github.com/... prefix, requiring manual editing in the browser address bar.