### PR TITLE
Fix build error on OpenBSD

### DIFF
--- a/intro/io.c
+++ b/intro/io.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <string.h>
 


### PR DESCRIPTION
According to [UNIX spec](http://pubs.opengroup.org/onlinepubs/7908799/xsh/sysstat.h.html), `S_IRUSR` and `S_IWUSR` should be defined in `<sys/stat.h>` file. The compilation is failed on `OpenBSD`:  

```
gcc -o io io.c -Wall
io.c: In function 'main':
io.c:9: error: 'S_IRUSR' undeclared (first use in this function)
io.c:9: error: (Each undeclared identifier is reported only once
io.c:9: error: for each function it appears in.)
io.c:9: error: 'S_IWUSR' undeclared (first use in this function)
*** Error 1 in /root/project/ostep-code/intro (Makefile:17 'io')
```

But OK on `Linux`. This patch makes build success on both OSs.