### PR TITLE
add print_stats to lottery.c to show the result statistics

### DIFF
--- a/cpu-sched-lottery/lottery.c
+++ b/cpu-sched-lottery/lottery.c
@@ -8,6 +8,7 @@ int gtickets = 0;
 
 struct node_t {
     int            tickets;
+    int            count;
     struct node_t *next;
 };
 
@@ -30,6 +31,15 @@ void print_list() {
 	curr = curr->next;
     }
     printf("\n");
+}
+
+void print_stats(int loops) {
+    struct node_t *curr = head;
+    printf("Stats:\n");
+    while (curr) {
+        printf("[%d]: %.3f %%\n", curr->tickets, (curr->count * 1. / loops) * 100);
+        curr = curr->next;
+    }
 }
 
 int
@@ -67,8 +77,10 @@ main(int argc, char *argv[])
 	// current is the winner: schedule it...
 	print_list();
 	printf("winner: %d %d\n\n", winner, current->tickets);
+    current->count += 1;
 
     }
+    print_stats(loops);
     return 0;
 }
 


### PR DESCRIPTION
By calling print_stats() before the exit of the program we can see that the scheduler does a fair scheduling according to tickets of the jobs.

For example when running

./lottery 1 100000

from command line, the results printed by print_stats() are

Stats:
[25]: 14.210 %
[100]: 57.180 %
[50]: 28.610 %


So we can see that there is a fair scheduling going on in this program.

We can add more jobs with insert(), and the program does not break working well with these modifications too.
