### PR TITLE
fix(args): Align invocation of `mem` program with OSTEP book.

### DIFF
--- a/intro/README.md
+++ b/intro/README.md
@@ -16,7 +16,7 @@ prompt> ./cpu A
 ```
 
 ```
-prompt> ./mem 1
+prompt> ./mem
 ```
 
 ```

--- a/intro/mem.c
+++ b/intro/mem.c
@@ -4,15 +4,11 @@
 #include "common.h"
 
 int main(int argc, char *argv[]) {
-    if (argc != 2) { 
-	fprintf(stderr, "usage: mem <value>\n"); 
-	exit(1); 
-    } 
     int *p; 
     p = malloc(sizeof(int));
     assert(p != NULL);
     printf("(%d) addr pointed to by p: %p\n", (int) getpid(), p);
-    *p = atoi(argv[1]); // assign value to addr stored in p
+    *p = 0; // assign value to addr stored in p
     while (1) {
 	Spin(1);
 	*p = *p + 1;


### PR DESCRIPTION
Hey @remzi-arpacidusseau, the invocation seen in the OSTEP book:

![image](https://user-images.githubusercontent.com/8067797/54158067-13013800-4420-11e9-8294-5209ed376589.png)
