### PR TITLE
intro/README: setarch and ARM

### DIFF
--- a/intro/README.md
+++ b/intro/README.md
@@ -44,9 +44,12 @@ Just compile/link as follows:
 From Giovanni Lagorio:
 
 Under Linux you can disable ASLR, without using a debugger, in (at least)  two ways:
-* Use the command setarch to run a process with ASLR disabled; I typically run
+* Use the command `setarch` to run a process with ASLR disabled; I typically run
   bash, with which I can execute examples, like this:
-  `setarch $(uname --machine) --addr-no-randomize /bin/bash`
+  `setarch $(uname --machine) --addr-no-randomize /bin/bash` 
+  
+  On ARM systems (such as the Raspberry Pi), the above `$(uname --machine)` returns `armv7l` 
+  or similar; instead of `$(uname --machine)` you can specify `linux32`.
 * Writing 0 into `/proc/sys/kernel/randomize_va_space`; you need to be
   root to do this and this change has (a non-permament) effect on the
   whole system, which is something you probably don't want. I use this


### PR DESCRIPTION
The `uname --machine` bit returns something like `armv7l` on ARM systems such as the Raspberry Pi, and this doesn't work -- but using `linux32` instead does.