### PR TITLE
Bugfix: stddef.h is needed for NULL

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -4,6 +4,7 @@
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <assert.h>
+#include <stddef.h>
 
 double GetTime() {
     struct timeval t;


### PR DESCRIPTION
`stddef.h` is needed for `NULL`.